### PR TITLE
Fixed array short syntax

### DIFF
--- a/NNTP/Client.php
+++ b/NNTP/Client.php
@@ -188,7 +188,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
 
 		switch ($_ret) {
 			case -1:
-				return ['Number' => (int)$response[0], 'Message-ID' => (string)$response[1]];
+				return array('Number' => (int)$response[0], 'Message-ID' => (string)$response[1]);
 				break;
 			case 0:
 				return (int)$response[0];
@@ -225,7 +225,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
 
 		switch ($_ret) {
 			case -1:
-				return ['Number' => (int)$response[0], 'Message-ID' => (string)$response[1]];
+				return array('Number' => (int)$response[0], 'Message-ID' => (string)$response[1]);
 				break;
 			case 0:
 				return (int)$response[0];
@@ -262,7 +262,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
 
 		switch ($_ret) {
 			case -1:
-				return ['Number' => (int)$response[0], 'Message-ID' => (string)$response[1]];
+				return array('Number' => (int)$response[0], 'Message-ID' => (string)$response[1]);
 				break;
 			case 0:
 				return (int)$response[0];
@@ -518,7 +518,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
 		$header .= "\r\n";
 
 		// Actually send the article
-		return $this->cmdPost2([$header, $body]);
+		return $this->cmdPost2(array($header, $body));
 	}
 
 	/**
@@ -552,11 +552,11 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
 						2) . ':' . substr($date, 12, 2));
 				break;
 			case 2:
-				return [
+				return array(
 					'y' => substr($date, 0, 4),
 					'm' => substr($date, 4, 2),
 					'd' => substr($date, 6, 2)
-				];
+                );
 				break;
 			default:
 				error();
@@ -773,11 +773,11 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
 				}
 
 				// Create and return API v1.0 compliant array
-				$articles = [];
+				$articles = array();
 				foreach ($overview as $article) {
 
 					// Rename 'Number' field into 'number'
-					$article = array_merge(['number' => array_shift($article)], $article);
+					$article = array_merge(array('number' => array_shift($article)), $article);
 
 					// Use 'Message-ID' field as key
 					$articles[$article['Message-ID']] = $article;
@@ -804,7 +804,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
 				}
 
 				// Prepend 'Number' field
-				$format = array_merge(['Number' => false], $format);
+				$format = array_merge(array('Number' => false), $format);
 
 				// Cache format
 				$this->_overviewFormatCache = $format;
@@ -882,7 +882,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
 		// Force name of first seven fields
 		if ($_forceNames) {
 			array_splice($format, 0, 7);
-			$format = array_merge([
+			$format = array_merge(array(
 				'Subject'    => false,
 				'From'       => false,
 				'Date'       => false,
@@ -890,7 +890,7 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
 				'References' => false,
 				':bytes'     => false,
 				':lines'     => false
-			], $format);
+            ), $format);
 		}
 
 		if ($_full) {

--- a/NNTP/Protocol/Client.php
+++ b/NNTP/Protocol/Client.php
@@ -128,8 +128,8 @@ class Net_NNTP_Protocol_Client
         // NET_NNTP and the server out of sync...
         if (preg_match_all('/\r?\n/', $cmd, $matches, PREG_PATTERN_ORDER)) {
             foreach ($matches[0] as $key => $match) {
-                $this->_logger->debug("Illegal character in command: " . htmlentities(str_replace(["\r", "\n"],
-                        ["'Carriage Return'", "'New Line'"], $match)));
+                $this->_logger->debug("Illegal character in command: " . htmlentities(str_replace(array("\r", "\n"),
+                        array("'Carriage Return'", "'New Line'"), $match)));
             }
             $this->throwError("Illegal character(s) in NNTP command!");
         }
@@ -183,10 +183,10 @@ class Net_NNTP_Protocol_Client
         // Trim the start of the response in case of misplased whitespace (should not be needen!!!)
         $response = ltrim($response);
 
-        $this->_currentStatusResponse = [
+        $this->_currentStatusResponse = array(
             (int)substr($response, 0, 3),
             (string)rtrim(substr($response, 4))
-        ];
+        );
 
         //
         return $this->_currentStatusResponse[0];
@@ -201,7 +201,7 @@ class Net_NNTP_Protocol_Client
      */
     function _getTextResponse()
     {
-        $data = [];
+        $data = array();
         $line = '';
 
         //
@@ -290,7 +290,7 @@ class Net_NNTP_Protocol_Client
      */
     function _getCompressedResponse()
     {
-        $data = [];
+        $data = array();
 
         // We can have two kinds of compressed support:
         //
@@ -762,12 +762,12 @@ class Net_NNTP_Protocol_Client
                     $this->_logger->info('Group selected: ' . $response_arr[3]);
                 }
 
-                return [
+                return array(
                     'group' => $response_arr[3],
                     'first' => $response_arr[1],
                     'last'  => $response_arr[2],
                     'count' => $response_arr[0]
-                ];
+                );
                 break;
             case NET_NNTP_PROTOCOL_RESPONSECODE_NO_SUCH_GROUP: // 411, RFC977: 'no such news group'
                 $this->throwError('No such news group', $response, $this->_currentStatusResponse());
@@ -806,22 +806,22 @@ class Net_NNTP_Protocol_Client
 
                 // If server does not return group summary in status response, return null'ed array
                 if (!is_numeric($response_arr[0]) || !is_numeric($response_arr[1]) || !is_numeric($response_arr[2]) || empty($response_arr[3])) {
-                    return [
+                    return array(
                         'group'    => null,
                         'first'    => null,
                         'last'     => null,
                         'count'    => null,
                         'articles' => $articles
-                    ];
+                    );
                 }
 
-                return [
+                return array(
                     'group'    => $response_arr[3],
                     'first'    => $response_arr[1],
                     'last'     => $response_arr[2],
                     'count'    => $response_arr[0],
                     'articles' => $articles
-                ];
+                );
                 break;
             case NET_NNTP_PROTOCOL_RESPONSECODE_NO_GROUP_SELECTED: // 412, RFC2980: 'Not currently in newsgroup'
                 $this->throwError('Not currently in newsgroup', $response, $this->_currentStatusResponse());
@@ -850,7 +850,7 @@ class Net_NNTP_Protocol_Client
                     $this->_logger->info('Selected previous article: ' . $response_arr[0] . ' - ' . $response_arr[1]);
                 }
 
-                return [$response_arr[0], (string)$response_arr[1]];
+                return array($response_arr[0], (string)$response_arr[1]);
                 break;
             case NET_NNTP_PROTOCOL_RESPONSECODE_NO_GROUP_SELECTED: // 412, RFC977: 'no newsgroup selected'
                 $this->throwError('No newsgroup has been selected', $response, $this->_currentStatusResponse());
@@ -883,7 +883,7 @@ class Net_NNTP_Protocol_Client
                     $this->_logger->info('Selected previous article: ' . $response_arr[0] . ' - ' . $response_arr[1]);
                 }
 
-                return [$response_arr[0], (string)$response_arr[1]];
+                return array($response_arr[0], (string)$response_arr[1]);
                 break;
             case NET_NNTP_PROTOCOL_RESPONSECODE_NO_GROUP_SELECTED: // 412, RFC977: 'no newsgroup selected'
                 $this->throwError('No newsgroup has been selected', $response, $this->_currentStatusResponse());
@@ -1069,7 +1069,7 @@ class Net_NNTP_Protocol_Client
                     $this->_logger->info('Selected article: ' . $response_arr[0] . ' - ' . $response_arr[1]);
                 }
 
-                return [$response_arr[0], (string)$response_arr[1]];
+                return array($response_arr[0], (string)$response_arr[1]);
                 break;
             case NET_NNTP_PROTOCOL_RESPONSECODE_NO_GROUP_SELECTED: // 412, RFC977: 'no newsgroup has been selected' (actually not documented, but copied from the ARTICLE command)
                 $this->throwError('No newsgroup has been selected', $response, $this->_currentStatusResponse());
@@ -1270,16 +1270,16 @@ class Net_NNTP_Protocol_Client
             case NET_NNTP_PROTOCOL_RESPONSECODE_NEW_GROUPS_FOLLOW: // 231, REF977: 'list of new newsgroups follows'
                 $data = $this->_getTextResponse();
 
-                $groups = [];
+                $groups = array();
                 foreach ($data as $line) {
                     $arr = explode(' ', trim($line));
 
-                    $group = [
+                    $group = array(
                         'group'   => $arr[0],
                         'last'    => $arr[1],
                         'first'   => $arr[2],
                         'posting' => $arr[3]
-                    ];
+                    );
 
                     $groups[$group['group']] = $group;
                 }
@@ -1323,7 +1323,7 @@ class Net_NNTP_Protocol_Client
 
         switch ($response) {
             case NET_NNTP_PROTOCOL_RESPONSECODE_NEW_ARTICLES_FOLLOW: // 230, RFC977: 'list of new articles by message-id follows'
-                $messages = [];
+                $messages = array();
                 foreach ($this->_getTextResponse() as $line) {
                     $messages[] = $line;
                 }
@@ -1353,16 +1353,16 @@ class Net_NNTP_Protocol_Client
         switch ($response) {
             case NET_NNTP_PROTOCOL_RESPONSECODE_GROUPS_FOLLOW: // 215, RFC977: 'list of newsgroups follows'
                 $data = $this->_getTextResponse();
-                $groups = [];
+                $groups = array();
                 foreach ($data as $line) {
                     $arr = explode(' ', trim($line));
 
-                    $group = [
+                    $group = array(
                         'group'   => $arr[0],
                         'last'    => $arr[1],
                         'first'   => $arr[2],
                         'posting' => $arr[3]
-                    ];
+                    );
 
                     $groups[$group['group']] = $group;
                 }
@@ -1397,16 +1397,16 @@ class Net_NNTP_Protocol_Client
             case NET_NNTP_PROTOCOL_RESPONSECODE_GROUPS_FOLLOW: // 215, RFC977: 'list of newsgroups follows'
                 $data = $this->_getTextResponse();
 
-                $groups = [];
+                $groups = array();
                 foreach ($data as $line) {
                     $arr = explode(' ', trim($line));
 
-                    $group = [
+                    $group = array(
                         'group'   => $arr[0],
                         'last'    => $arr[1],
                         'first'   => $arr[2],
                         'posting' => $arr[3]
-                    ];
+                    );
 
                     $groups[$group['group']] = $group;
                 }
@@ -1445,7 +1445,7 @@ class Net_NNTP_Protocol_Client
             case NET_NNTP_PROTOCOL_RESPONSECODE_GROUPS_FOLLOW: // 215, RFC2980: 'information follows'
                 $data = $this->_getTextResponse();
 
-                $groups = [];
+                $groups = array();
 
                 foreach ($data as $line) {
                     if (preg_match("/^(\S+)\s+(.*)$/", ltrim($line), $matches)) {
@@ -1587,8 +1587,8 @@ class Net_NNTP_Protocol_Client
      */
     private function yencDecode($string, $destination = "")
     {
-        $encoded = [];
-        $header = [];
+        $encoded = array();
+        $header = array();
         $decoded = '';
 
         # Extract the yEnc string itself
@@ -1689,7 +1689,7 @@ class Net_NNTP_Protocol_Client
             case NET_NNTP_PROTOCOL_RESPONSECODE_GROUPS_FOLLOW: // 215, RFC2980: 'information follows'
                 $data = $this->_getTextResponse();
 
-                $format = [];
+                $format = array();
 
                 foreach ($data as $line) {
 
@@ -1742,7 +1742,7 @@ class Net_NNTP_Protocol_Client
             case 221: // 221, RFC2980: 'Header follows'
                 $data = $this->_getTextResponse();
 
-                $return = [];
+                $return = array();
                 foreach ($data as $line) {
                     $line = explode(' ', trim($line), 2);
                     $return[$line[0]] = $line[1];
@@ -1785,7 +1785,7 @@ class Net_NNTP_Protocol_Client
             case 282: // RFC2980: 'list of groups and descriptions follows'
                 $data = $this->_getTextResponse();
 
-                $groups = [];
+                $groups = array();
 
                 foreach ($data as $line) {
                     preg_match("/^(.*?)\s(.*?$)/", trim($line), $matches);
@@ -1830,7 +1830,7 @@ class Net_NNTP_Protocol_Client
             case NET_NNTP_PROTOCOL_RESPONSECODE_OVERVIEW_FOLLOWS: // 224, RFC2980: 'Overview information follows'
                 $data = $this->_getTextResponse();
 
-                $return = [];
+                $return = array();
                 foreach ($data as $line) {
                     $line = explode(' ', trim($line), 2);
                     $return[$line[0]] = $line[1];
@@ -1872,7 +1872,7 @@ class Net_NNTP_Protocol_Client
             case 221: // 221, RFC2980: 'Header follows'
                 $data = $this->_getTextResponse();
 
-                $return = [];
+                $return = array();
                 foreach ($data as $line) {
                     $line = explode(' ', trim($line), 2);
                     $return[$line[0]] = $line[1];


### PR DESCRIPTION
Changed arrays from short syntax to long syntax because I accidentally changed them to short syntax by auto formatting. This would normally be no problem but PHP 5.3 doesn't support them, this is required for spotweb.