### PR TITLE
Hotfix for Responsecode.php loading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
   "autoload": {
     "classmap": [
       "./"
+    ],
+    "files": [
+      "NNTP/Protocol/Responsecode.php"
     ]
   },
   "license": "MIT",


### PR DESCRIPTION
In release 1.1.0 the `require` is missing from `Protocol/Client.php`, Added loading of Responsecode.php file in composer.json.